### PR TITLE
feat: 分步动画播放器支持全屏

### DIFF
--- a/client/src/components/knowledge-page/ManimCodePlayer.vue
+++ b/client/src/components/knowledge-page/ManimCodePlayer.vue
@@ -13,6 +13,14 @@ const sceneHost = ref<HTMLElement | null>(null);
 const sceneRef = shallowRef<Scene | null>(null);
 const isRendering = ref(false);
 let renderToken = 0;
+const rootEl = ref<HTMLElement | null>(null);
+const isFullscreen = ref(false);
+
+const supportsFullscreen = computed(
+  () =>
+    typeof document !== "undefined" &&
+    typeof document.documentElement.requestFullscreen === "function",
+);
 
 const stepCount = computed(() => props.animation.steps.length);
 const progress = computed(() =>
@@ -55,12 +63,13 @@ async function initScene() {
   sceneRef.value?.dispose();
   const config = props.animation.scene;
   sceneRef.value = new Scene(sceneHost.value, {
-    width: config.width,
-    height: config.height,
     frameWidth: config.frameWidth,
     frameHeight: config.frameHeight,
     backgroundColor: config.backgroundColor,
   });
+  // 省略 width/height 让画布跟随容器尺寸自动重绘（全屏切换时无需重建）；
+  // contain 模式保证容器宽高比与画面帧不一致时信箱式留白而非裁剪内容。
+  sceneRef.value.camera.aspectMode = "contain";
   await renderCurrentStep(true);
 }
 
@@ -82,6 +91,20 @@ function reset() {
   void renderCurrentStep(true);
 }
 
+function toggleFullscreen() {
+  const el = rootEl.value;
+  if (!el) return;
+  if (document.fullscreenElement === el) {
+    document.exitFullscreen().catch(() => {});
+  } else {
+    el.requestFullscreen().catch(() => {});
+  }
+}
+
+function syncFullscreenState() {
+  isFullscreen.value = document.fullscreenElement === rootEl.value;
+}
+
 watch(current, () => {
   void renderCurrentStep(true);
 });
@@ -95,10 +118,12 @@ watch(
 );
 
 onMounted(() => {
+  document.addEventListener("fullscreenchange", syncFullscreenState);
   void initScene();
 });
 
 onUnmounted(() => {
+  document.removeEventListener("fullscreenchange", syncFullscreenState);
   sceneRef.value?.dispose();
   sceneRef.value = null;
 });
@@ -106,21 +131,70 @@ onUnmounted(() => {
 
 <template>
   <div
-    class="overflow-hidden rounded-[4px] border border-[#d6dee9] bg-white"
+    ref="rootEl"
+    :class="
+      isFullscreen
+        ? 'flex h-full w-full flex-col bg-white'
+        : 'overflow-hidden rounded-[4px] border border-[#d6dee9] bg-white'
+    "
     :aria-label="animation.ariaLabel"
   >
     <header
-      class="flex items-center justify-between gap-5 border-b border-[#e0e6ee] px-[clamp(14px,2vw,22px)] py-3"
+      class="flex shrink-0 items-center justify-between gap-5 border-b border-[#e0e6ee] px-[clamp(14px,2vw,22px)] py-3"
     >
       <p class="m-0 text-[12px] font-semibold tracking-[.02em] text-slate-500">
         分步动画
       </p>
+      <button
+        v-if="supportsFullscreen"
+        class="flex shrink-0 items-center gap-1.5 text-[12px] font-semibold text-slate-500 transition hover:text-[#071225]"
+        type="button"
+        :aria-label="isFullscreen ? '退出全屏' : '进入全屏'"
+        @click="toggleFullscreen"
+      >
+        <svg
+          v-if="isFullscreen"
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M8 3v3a2 2 0 0 1-2 2H3" />
+          <path d="M21 8h-3a2 2 0 0 1-2-2V3" />
+          <path d="M3 16h3a2 2 0 0 1 2 2v3" />
+          <path d="M16 21v-3a2 2 0 0 1 2-2h3" />
+        </svg>
+        <svg
+          v-else
+          class="h-3.5 w-3.5"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          aria-hidden="true"
+        >
+          <path d="M8 3H5a2 2 0 0 0-2 2v3" />
+          <path d="M21 8V5a2 2 0 0 0-2-2h-3" />
+          <path d="M3 16v3a2 2 0 0 0 2 2h3" />
+          <path d="M16 21h3a2 2 0 0 0 2-2v-3" />
+        </svg>
+        {{ isFullscreen ? "退出全屏" : "全屏" }}
+      </button>
     </header>
 
-    <div class="bg-[#f7f8fa] p-2">
+    <div :class="isFullscreen ? 'min-h-0 flex-1' : 'bg-[#f7f8fa] p-2'">
       <div
-        class="relative w-full overflow-hidden border border-[#e0e5eb] bg-white"
-        :style="{ aspectRatio: sceneAspectRatio }"
+        class="relative overflow-hidden"
+        :class="
+          isFullscreen ? 'h-full w-full' : 'w-full border border-[#e0e5eb] bg-white'
+        "
+        :style="isFullscreen ? undefined : { aspectRatio: sceneAspectRatio }"
         role="img"
         :aria-label="animation.ariaLabel"
       >
@@ -131,7 +205,7 @@ onUnmounted(() => {
       </div>
     </div>
 
-    <footer class="border-t border-[#d8e1ec] bg-white">
+    <footer class="shrink-0 border-t border-[#d8e1ec] bg-white">
       <div
         class="flex items-center justify-between gap-4 px-[clamp(14px,2vw,22px)] py-3 max-sm:items-end"
       >

--- a/client/src/content/knowledge-articles/computer-organization/memory-hierarchy.ts
+++ b/client/src/content/knowledge-articles/computer-organization/memory-hierarchy.ts
@@ -61,7 +61,7 @@ export const memory_hierarchyArticle: KnowledgeArticleData = {
         {
           id: 'kb-co-memory-hierarchy-6-1',
           type: 'paragraph',
-          text: '**RAM**（随机存取存储器）：可读可写，按地址随机访问，访问时间与位置无关。\n\n**易失性**：断电后数据丢失。\n\n半导体 RAM 按存储原理分 **SRAM 和 DRAM** 两种，用作主存和 Cache。',
+          text: '**RAM**（随机存取存储器）：可读可写，按地址随机访问，访问时间与位置无关。\n\n**易失性**：断电后数据丢失。\n\n半导体 RAM 按存储原理分 **SRAM 和 DRAM** 两种，用作 Cache 和主存。',
         },
         {
           id: 'kb-co-memory-hierarchy-6-2',

--- a/client/src/content/knowledge-articles/computer-organization/memory-hierarchy.ts
+++ b/client/src/content/knowledge-articles/computer-organization/memory-hierarchy.ts
@@ -48,7 +48,6 @@ export const memory_hierarchyArticle: KnowledgeArticleData = {
   <text x="410" y="246" class="layer-name">外存（磁盘 / SSD）</text>
   <text x="410" y="266" class="layer-ex">100 μs ~ 15 ms</text>
 
-  <line x1="410" y1="54" x2="410" y2="276" stroke="#cbd5e1" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="410" y="304" class="note">上一层存储器作为下一层的高速缓存</text>
 </svg>`,
         }


### PR DESCRIPTION
## 改动内容

本 PR 包含 1 个功能新增与 2 个内容修正，共 3 个提交。

### feat: 分步动画播放器支持全屏 (3edfd7a)

为分步动画播放器 `ManimCodePlayer` 添加浏览器原生全屏功能，全屏下动画放大显示、信息更清晰。改动仅涉及 `client/src/components/knowledge-page/ManimCodePlayer.vue`。

- 播放器头部新增「全屏 / 退出全屏」按钮（Fullscreen API，Esc 可直接退出；不支持的环境按钮自动隐藏）
- 全屏时播放器纵向 flex 铺满视口：头部与底部控制栏保留，动画区占满剩余空间
- 构造 manim-web `Scene` 时省略 `width/height` 以启用其 `autoResize`：进入/退出全屏时画布自动按新尺寸重设分辨率并重绘当前帧，无需销毁重建场景，步进进度不丢失
- 设置 `scene.camera.aspectMode = "contain"`：屏幕宽高比与画面帧不一致时信箱式留白而非裁剪，任何屏幕比例下内容完整可见
- 附带改进：普通模式画布分辨率跟随实际显示尺寸（× devicePixelRatio，上限 2），HiDPI 屏幕更清晰

### fix: 修正 RAM 描述中 Cache 与主存的顺序 (e53b112)

`memory-hierarchy.ts` 中半导体 RAM 一段，「SRAM 和 DRAM **用作主存和 Cache**」修正为「**用作 Cache 和主存**」——SRAM 用作 Cache、DRAM 用作主存，先 Cache 后主存的顺序与两种器件的用途一一对应，表述更准确。

### fix: 删除存储层次结构图中的多余虚线 (b3a282e)

存储层次 SVG 结构图删除了一条贯穿各层的垂直虚线，避免其穿过右侧「上一层存储器作为下一层的高速缓存」说明区域，图面更干净。

## 验证

- 全屏功能浏览器实测：进入全屏后画布自动重建为全屏尺寸并正确重绘；全屏内逐步播放、进度条正常；退出后布局与画布尺寸完全恢复
- `vue-tsc` 对本次改动无新增报错
